### PR TITLE
修复 ttl = async 情景时 清理缓存的问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,16 +91,20 @@ function buildIntermediateFunction(
 
       if (ttl === 'async') {
         // tslint:disable-next-line:no-floating-promises
-        Promise.resolve(cache).then(() => cacheMap.delete(keys));
+        Promise.resolve(cache).then(cleanUp, cleanUp);
       } else if (ttl !== Infinity) {
         if (ttl === false) {
-          asap(() => cacheMap.delete(keys));
+          asap(cleanUp);
         } else {
-          setTimeout(() => cacheMap.delete(keys), ttl);
+          setTimeout(cleanUp, ttl);
         }
       }
     }
 
     return cache;
+
+    function cleanUp() {
+      cacheMap.delete(keys);
+    }
   }
 }

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -147,7 +147,7 @@ describe('memorize', () => {
 
     it('should handle ttl being "async"', async () => {
       let values = [123, 456, 789];
-      let instable = true;
+      let unstable = true;
 
       class Foo {
         @memorize({ttl: 'async'})
@@ -157,9 +157,9 @@ describe('memorize', () => {
         }
 
         @memorize({ttl: 'async'})
-        async getInstableValue(): Promise<number> {
+        async getUnstableValue(): Promise<number> {
           await new Promise<void>((resolve, reject) => {
-            if (instable) {
+            if (unstable) {
               reject();
             } else {
               setTimeout(resolve, 10);
@@ -185,12 +185,12 @@ describe('memorize', () => {
       let f = 0;
 
       try {
-        await Promise.all([foo.getInstableValue(), foo.getInstableValue()]);
+        await Promise.all([foo.getUnstableValue(), foo.getUnstableValue()]);
       } catch (err) {
-        instable = false;
+        unstable = false;
         [e, f] = await Promise.all([
-          foo.getInstableValue(),
-          foo.getInstableValue(),
+          foo.getUnstableValue(),
+          foo.getUnstableValue(),
         ]);
       }
 


### PR DESCRIPTION
### 解决问题

```javascript
class Test {
   @memorize({ ttl:'async' })
   function test() {
     console.log('test');
     return new Promise((resolve, reject) => {  setTime(reject, 1000) });  
   }
}

let obj = new Test();

obj.test();
obj.test();
setTimeout(() => obj.test(), 3000);
```

### output

```
test
```

函数返回的 Promise 状态是 rejected 时，memorize 没有处理掉缓存